### PR TITLE
Proofreading done

### DIFF
--- a/design-docs/handshake-core.md
+++ b/design-docs/handshake-core.md
@@ -141,7 +141,7 @@ NOTE: Each chat participant uses their own lookup table to compose messages, and
 The message posting pattern can be covered in three parts:
 
 1. Bob encrypts a message with a one-time key and submits this payload to message storage.
-2. Message storage returns a hash of the contents of the payload which is used as the URL address.
+2. Message storage returns a hash of the contents of the payload, which is used as the URL address.
 3. Bob encrypts this hash with a second one-time key and submits this latest message to his rendezvous point.
 
 ### Message Retrieval Pattern
@@ -292,7 +292,7 @@ NOTE: One important thing to consider with fetch is that it not only potentially
 
 ### Chats
 
-A chat is generated after a handshake is complete in storage it contains a randomly generated id for the chat. A unique chat group is namespaced with the prefix `chats/{chat_id}/{profile_id}/`
+A chat is generated after a handshake is complete. In storage, it contains a randomly generated id for the chat. A unique chat group is namespaced with the prefix `chats/{chat_id}/{profile_id}/`
 
 and it contains three important sections:
 


### PR DESCRIPTION
All done on this one! Just a couple of questions again to make sure I'm not changing the meaning of anything technical. As with the  blurb, feel free to either make the changes yourself or ask me and I'll happily do them. 

I just want to highlight that I changed 'cypher-text' to 'cipher text' as it was written that way everywhere else. Is that okay or is 'cypher-text' a different thing? Likewise, I noticed an instance of 'cipher_text', which I've left as is just in case. 

'Message storage returns a hash of the contents of the payload which is used as the URL address.' I think this needs a comma for clarity, but placement depends on the meaning. If you mean message storage returns a hash of the payload contents, and then that hash is used as the URL address, you need a comma between 'payload' and 'which'. Currently, without a comma, it could mean the payload is used as the URL address. (I have no idea which of those is a real concept or if one's impossible, sorry!)

'A chat is generated after a handshake is complete in storage it contains a randomly generated id for the chat.' I would recommend breaking this up into two sentences, but again it depends on the meaning. Is the chat generated after the handshake is complete in storage, or does storage contain a randomly generated id for the chat? 

It'll be ''A chat is generated after a handshake is complete in storage. It contains a randomly generated id for the chat.' or 'A chat is generated after a handshake is complete. In storage, it contains a randomly generated id for the chat.' respectively. Or even 'A chat is generated. After a handshake is complete in storage, it contains a randomly generated id for the chat.'

Apologies for all the queries but I hope they make sense.